### PR TITLE
【新增】New docker image for Linux and actions for auto push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,40 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: true
+          tags: chenyme/chenyme-AAVT:${{ github.sha }}
+            

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,5 +36,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-          tags: chenyme/chenyme-AAVT:${{ github.sha }}
+          tags: chenyme/chenyme-aavt:latest,chenyme/chenyme-aavt:${{ github.sha }}
             

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,13 +3,11 @@ name: Docker Image CI
 on:
   pull_request:
     branches: [ main ]
-    types: [ closed ]
   push:
     branches: [ main ]
 
 jobs:
   docker:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11
+
+EXPOSE 8501
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY . /app
+
+RUN apt update && \
+    apt install ffmpeg rsync fonts-wqy-zenhei fonts-wqy-microhei -y && \
+    apt clean && \
+    addgroup --gid 1000 chenymeaavt && \
+    adduser --uid 1000 --ingroup chenymeaavt --disabled-password chenymeaavt && \
+    pip cache purge && \
+    chown 1000:1000 /app -R && \
+    chmod +x /app/entry.sh
+
+USER chenymeaavt
+WORKDIR /app
+
+RUN python -m venv . && \
+    . ./bin/activate && \
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 && \
+    pip install -r /app/requirements.txt && \
+    pip cache purge && \
+    mv config _config && \
+    mv cache _cache && \
+    mv model _model && \
+    mkdir config cache model
+
+ENTRYPOINT ["./entry.sh"]

--- a/README-EN.md
+++ b/README-EN.md
@@ -156,7 +156,7 @@ Basic supported features, not all features:
 > ```
 > ### 3. Run the Project Web
 > ```
-> streamlit run Chenyme-AAVT
+> streamlit run Chenyme-AAVT.py
 > ```
 >  - Enter `chenymeaavt` to access the project (this is a protection feature of the new version, can be turned off)
 >

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@
 > ```
 > ### 3. 运行项目Web
 > ```
-> streamlit run Chenyme-AAVT
+> streamlit run Chenyme-AAVT.py
 > ```
 >  - 输入 `chenymeaavt` 进入项目（此为新版本的保护功能，可关闭）
 >

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
 services:
   chenyme-aavt:
     container_name: chenyme-aavt
-    image: chenymeaavt:test
+    image: chenyme/chenyme-aavt:latest
     restart: unless-stopped
     networks:
       - chenyme-aavt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+networks:
+  chenyme-aavt:
+
+services:
+  chenyme-aavt:
+    container_name: chenyme-aavt
+    image: chenymeaavt:test
+    restart: unless-stopped
+    networks:
+      - chenyme-aavt
+    ports:
+      - "8501:8501"        # Web GUI
+    volumes:
+      - './conf:/app/config'
+      - './model:/app/model'
+      - './output:/app/cache'        # Output

--- a/entry.sh
+++ b/entry.sh
@@ -6,4 +6,4 @@ rsync -a --ignore-existing /app/_cache/ /app/cache/ > /dev/null
 
 . ./bin/activate
 python ./styles/info.py
-streamlit run Chenyme-AAVT.py
+streamlit run Chenyme-AAVT.py --browser.gatherUsageStats false

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+rsync -a --ignore-existing /app/_config/ /app/config/ > /dev/null
+rsync -a --ignore-existing /app/_model/ /app/model/ > /dev/null
+rsync -a --ignore-existing /app/_cache/ /app/cache/ > /dev/null
+
+. ./bin/activate
+python ./styles/info.py
+streamlit run Chenyme-AAVT.py

--- a/utils/get_font.py
+++ b/utils/get_font.py
@@ -23,7 +23,7 @@ def get_font_data():
             for font in fonts:
                 file.write(font + "\n")
 
-    elif system_type in ["Linux", "Darwin"]:
+    elif system_type in ["Darwin"]:
         import subprocess
         import re
 
@@ -34,6 +34,18 @@ def get_font_data():
         with open(path, 'w', encoding='utf-8') as file:
             for font in fonts:
                 file.write(font + "\n")
+                
+    elif system_type in ["Linux"]:
+        import subprocess
+        
+        result = subprocess.run(['fc-list', ':', 'family'], capture_output=True, text=True)
+        output = result.stdout
+        fonts = output.split('\n')
+        path = os.path.join(os.getcwd().replace("utils", ""), 'config', 'font.txt')
+        with open(path, 'w', encoding='utf-8') as file:
+            for font in fonts:
+                if font:
+                    file.write(font + "\n")
 
     else:
         print(f"获取字体失败！尚未支持的操作系统: {system_type}")


### PR DESCRIPTION
### **需要修改**

如题，添加了Linux下的Dockerfile
并且在Push和Pull的时候会自动在github上build docker镜像，再用你的账号推送到docker.io
因此在激活actions之前需要先设置下你docker账号的凭据
（Github 项目主页> Settings > Secrets and variables > Actions)
添加`DOCKERHUB_USERNAME`和`DOCKERHUB_TOKEN`两个新secret用于推送docker镜像
如果暂时不想用，也可以先把actions禁用

完成之后将`Chenyme-AAVT\.github\workflows\docker-image.yml`中的tag，改为你自己的
```
      - name: Build and push
        uses: docker/build-push-action@v6
        with:
          context: .
          platforms: linux/amd64,linux/arm64
          pull: true
          push: true
    >     tags: chenyme/chenyme-aavt:latest,chenyme/chenyme-aavt:${{ github.sha }}
```
相应的，也修改下`Chenyme-AAVT\docker-compose.yaml`中的tag
```
services:
  chenyme-aavt:
    container_name: chenyme-aavt
 >  image: chenyme/chenyme-aavt:latest
    restart: unless-stopped
    networks:
      - chenyme-aavt
```

最后Linux下如果要输出中文硬字幕，需要先设置下中文字体，否则会输出框框
生成的文件都在output目录下